### PR TITLE
Insert placemark with icon

### DIFF
--- a/Src/CmdLineArgProcessor/u_CmdLineArgProcessor.pas
+++ b/Src/CmdLineArgProcessor/u_CmdLineArgProcessor.pas
@@ -228,6 +228,7 @@ begin
     VParser.AddArgument('--navigate', saStore);         // --navigate=({lon},{lat})
     VParser.AddArgument('--show-placemarks', saStore);  // --show-placemarks={0/1}
     VParser.AddArgument('--insert-placemark', saStore); // --insert-placemark="{name}";({lon},{lat});"{desc}"
+    VParser.AddArgument('--insert-placemark-with-icon', saStore); // --insert-placemark-with-icon="{name}";({lon},{lat});"{icon}";"{desc}"
     VParser.AddArgument('--sls-autostart', saBool);     // --sls-autostart
 
     VParseResult := VParser.ParseArgs(AList);
@@ -291,6 +292,12 @@ begin
       if VParseResult.HasArgument('insert-placemark') then begin
         VStrValue := VParseResult.GetValue('insert-placemark');
         ProcessImportPlacemark(VStrValue, FMarkSystem, FGeometryLonLatFactory);
+      end;
+
+      if VParseResult.HasArgument('insert-placemark-with-icon') then begin
+        VStrValue := VParseResult.GetValue('insert-placemark-with-icon');
+        ProcessImportPlacemarkWithIcon(
+          VStrValue, FMarkSystem, FGeometryLonLatFactory, True);
       end;
 
       VStartSlsPaused := not VParseResult.HasArgument('sls-autostart');

--- a/Src/CmdLineArgProcessor/u_CmdLineArgProcessorAPI.pas
+++ b/Src/CmdLineArgProcessor/u_CmdLineArgProcessorAPI.pas
@@ -91,6 +91,11 @@ begin
     '                            Insert the given placemark into the    ' + CR +
     '                            temporary database                     ' + CR +
                                                                             CR +
+    '    --insert-placemark-with-icon=                                  ' + CR +
+    '        "<name>";(<lon>,<lat>);"<icon>";"<desc>"                   ' + CR +
+    '                            Insert the given placemark into the    ' + CR +
+    '                            temporary database with icon           ' + CR +
+                                                                            CR +
     '    --sls-autostart         Run download from saved session (*.sls)' + CR +
     '                            immediately. Without this option       ' + CR +
     '                            dounload will be started in paused     ' + CR +


### PR DESCRIPTION
В последних версиях SAS Planet аргумент `--insert-placemark` добавляет метки без иконок. Например, вот результат выполнения `SASPlanet.exe --insert-placemark="Test";(40.0,60.0);"Description"`:
![insert-placemark](https://github.com/sasgis/sas.planet.src/assets/142790/369d1819-3064-4049-b2c4-226d0dbfdae0)

PR исправляет ошибку и добавляет новый аргумент `--insert-placemark-with-icon` с возможностью указать иконку для метки.
Примеры использования:
`SASPlanet.exe --insert-placemark-with-icon="Point with description";(40.0,50.0);A.png;"Description"`
`SASPlanet.exe --insert-placemark-with-icon="Point without description";(40.0,40.0);A.png`
`SASPlanet.exe --insert-placemark-with-icon="Point with invalid icon";(40.0,30.0);Invalid.png`